### PR TITLE
Fix InventoryTable column field

### DIFF
--- a/components/ui/InventoryTable.tsx
+++ b/components/ui/InventoryTable.tsx
@@ -31,7 +31,7 @@ export default function InventoryTable({ data }: { data: any[] }) {
           {data.map((row) => (
             <tr key={row.id} onContextMenu={(e) => handleContextMenu(e, row)}>
               <td>{row.machine_name}</td>
-              <td>{row.model}</td>
+              <td>{row.type}</td>
               <td>{row.maker}</td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- correct table column to use `type` instead of nonexistent `model`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a6d9fdfb08332a666559e1c37d2e1