### PR TITLE
Update OCR uploader to use certificate_date

### DIFF
--- a/app/admin/inventory/input/OCRUploader.tsx
+++ b/app/admin/inventory/input/OCRUploader.tsx
@@ -36,7 +36,7 @@ export default function OCRUploader({ setFormData }: Props) {
       const {
         maker,
         machine_name,
-        inspection_date,
+        certificate_date,
         board_serial,
         frame_serial,
         main_board,
@@ -47,7 +47,7 @@ export default function OCRUploader({ setFormData }: Props) {
         ...prev,
         maker,
         machine_name,
-        inspection_date,
+        certificate_date,
         board_serial,
         frame_serial,
         main_board_serial: main_board,


### PR DESCRIPTION
## Summary
- fix OCR uploader to update `certificate_date` instead of `inspection_date`

## Testing
- `npm install`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_685b4ab58eac8332997c5868fb112866