### PR TITLE
Fix indentation for editTarget line

### DIFF
--- a/app/admin/inventory/page.tsx
+++ b/app/admin/inventory/page.tsx
@@ -61,7 +61,7 @@ export default function AdminInventoryPage() {
   const [showFilters, setShowFilters]         = useState(false)
   const [selectedColumns, setSelectedColumns] = useState<string[]>(columns.map(c => c.key))
   const [showModal, setShowModal] = useState(false)         // モーダルを開く状態
-　const [editTarget, setEditTarget] = useState<any>()       // 編集したいデータ
+  const [editTarget, setEditTarget] = useState<any>() // 編集したいデータ
   const [mobileMenuRow, setMobileMenuRow] = useState<any | null>(null)
   
 


### PR DESCRIPTION
## Summary
- remove fullwidth space before `editTarget` state declaration in `app/admin/inventory/page.tsx`
- run formatter on the modified section

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_685b4ab5d2008332aa4dbde079d151b4