### PR TITLE
Hide mobile bulk CSV and filter buttons

### DIFF
--- a/app/admin/inventory/page.tsx
+++ b/app/admin/inventory/page.tsx
@@ -239,7 +239,7 @@ const exportToCSV = (row: any) => {
         <div className="flex flex-wrap items-center gap-2 mb-4">
           <Button
             onClick={() => document.getElementById('csv-hidden-input')?.click()}
-            className="bg-[#191970] text-white hover:bg-[#15155d]"
+            className="bg-[#191970] text-white hover:bg-[#15155d] hidden sm:inline-flex"
           >
             一括CSV登録
           </Button>
@@ -261,7 +261,7 @@ const exportToCSV = (row: any) => {
 
           <Button
             onClick={() => setShowFilters(!showFilters)}
-            className="bg-[#191970] text-white hover:bg-[#15155d]"
+            className="bg-[#191970] text-white hover:bg-[#15155d] hidden sm:inline-flex"
           >
             項目を絞り込む
           </Button>


### PR DESCRIPTION
## Summary
- on mobile, don't show Bulk CSV Import button
- on mobile, don't show column filter button

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b4e8e1b50833282c7bc2fab1fde9a