### PR TITLE
Fix mobile context menu text

### DIFF
--- a/app/admin/inventory/page.tsx
+++ b/app/admin/inventory/page.tsx
@@ -327,10 +327,12 @@ const exportToCSV = (row: any) => {
               {entries.map(row => (
                 <tr
   key={row.id}
-  className="hover:bg-gray-50 relative"
+  className="hover:bg-gray-50 relative select-none"
   onContextMenu={e => {
     e.preventDefault();
-    setContextMenu({ x: e.clientX, y: e.clientY, row });
+    if (window.innerWidth >= 640) {
+      setContextMenu({ x: e.clientX, y: e.clientY, row });
+    }
   }}
   onClick={() => {
     if (window.innerWidth < 640) setMobileMenuRow(row);   // スマホだけ行タップ

--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -13,7 +13,9 @@ export default function TestPage() {
   const handleContextMenu = (e: React.MouseEvent, row: any) => {
     e.preventDefault()
     console.log('右クリック検知:', row)
-    setContextMenu({ x: e.clientX, y: e.clientY, row })
+    if (window.innerWidth >= 640) {
+      setContextMenu({ x: e.clientX, y: e.clientY, row })
+    }
   }
 
   useEffect(() => {
@@ -33,7 +35,11 @@ export default function TestPage() {
         </thead>
         <tbody>
           {sampleData.map((row) => (
-            <tr key={row.id} onContextMenu={(e) => handleContextMenu(e, row)} className="border hover:bg-gray-100">
+            <tr
+              key={row.id}
+              onContextMenu={(e) => handleContextMenu(e, row)}
+              className="border hover:bg-gray-100 select-none"
+            >
               <td className="border p-2">{row.name}</td>
               <td className="border p-2">{row.maker}</td>
             </tr>

--- a/components/ui/InventoryTable.tsx
+++ b/components/ui/InventoryTable.tsx
@@ -14,7 +14,9 @@ export default function InventoryTable({ data }: { data: any[] }) {
 
   const handleContextMenu = (e: React.MouseEvent, row: any) => {
     e.preventDefault()
-    setContextMenu({ x: e.clientX, y: e.clientY, row })
+    if (window.innerWidth >= 640) {
+      setContextMenu({ x: e.clientX, y: e.clientY, row })
+    }
   }
 
   return (
@@ -29,7 +31,11 @@ export default function InventoryTable({ data }: { data: any[] }) {
         </thead>
         <tbody>
           {data.map((row) => (
-            <tr key={row.id} onContextMenu={(e) => handleContextMenu(e, row)}>
+            <tr
+              key={row.id}
+              onContextMenu={(e) => handleContextMenu(e, row)}
+              className="select-none"
+            >
               <td>{row.machine_name}</td>
               <td>{row.type}</td>
               <td>{row.maker}</td>


### PR DESCRIPTION
## Summary
- prevent custom context menu from opening on small screens
- disable text selection on table rows to avoid long-press hints

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b4dffc43883329d26ac6113b0102e