### PR TITLE
Use environment variables for Supabase config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables required to run the application
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,6 +1,6 @@
 // lib/supabase.ts
 import { createClient } from '@supabase/supabase-js'
 
-const supabaseUrl = 'https://bpxvonpgtsvgjhzrlxjc.supabase.co'
-const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJweHZvbnBndHN2Z2poenJseGpjIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk2OTYxNDksImV4cCI6MjA2NTI3MjE0OX0.MwaKknR5hcbs3T6g_DL-iu-9jKS0c-Ta6NLWt7LG71k'
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
 export const supabase = createClient(supabaseUrl, supabaseKey)


### PR DESCRIPTION
## Summary
- replace hard-coded Supabase credentials with environment variables
- add `.env.example` to document required variables
- allow `.env.example` through `.gitignore`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b53395654833298f873a470d6133f