### PR TITLE
Add basic Supabase auth pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+### Authentication
+
+Use `/signup` to create an account and `/login` to access the app. After sign-up a default warehouse record is created automatically.

--- a/app/api/create-default-warehouse/route.ts
+++ b/app/api/create-default-warehouse/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+export async function POST(req: NextRequest) {
+  const { user_id } = await req.json()
+  if (!user_id) {
+    return NextResponse.json({ error: 'user_id required' }, { status: 400 })
+  }
+  const { error, data } = await supabase
+    .from('warehouses')
+    .insert({ user_id, name: 'default' })
+    .single()
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+  return NextResponse.json({ success: true, data })
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      if (data.user) router.replace('/admin/inventory')
+    })
+  }, [router])
+
+  const handleLogin = async () => {
+    setError(null)
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) {
+      setError(error.message)
+    } else {
+      router.replace('/admin/inventory')
+    }
+  }
+
+  return (
+    <div className="max-w-sm mx-auto mt-20 space-y-4">
+      <h1 className="text-xl font-bold text-center">ログイン</h1>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <Input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+      />
+      <Input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      <Button className="w-full" onClick={handleLogin}>ログイン</Button>
+    </div>
+  )
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function SignupPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      if (data.user) router.replace('/admin/inventory')
+    })
+  }, [router])
+
+  const handleSignup = async () => {
+    setError(null)
+    const { data, error } = await supabase.auth.signUp({ email, password })
+    if (error || !data.user) {
+      setError(error?.message || 'signup failed')
+      return
+    }
+    await fetch('/api/create-default-warehouse', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: data.user.id }),
+    })
+    router.replace('/admin/inventory')
+  }
+
+  return (
+    <div className="max-w-sm mx-auto mt-20 space-y-4">
+      <h1 className="text-xl font-bold text-center">サインアップ</h1>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <Input
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+      />
+      <Input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      <Button className="w-full" onClick={handleSignup}>登録</Button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `/login` and `/signup` pages using `supabase.auth`
- create a server route to insert a default warehouse on sign-up
- document how to login and sign up

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b533b48f08332b029e38385d6f70e