### PR TITLE
Add env path for GCP Vision key

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+### Google Cloud Vision
+
+OCR features require a Google Cloud Vision service account key. Place the JSON
+key at `gcp-vision-key.json` in the project root or specify a custom path using
+the `GCP_VISION_KEY_PATH` environment variable when running the server.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/app/api/upload-ocr/route.ts
+++ b/app/api/upload-ocr/route.ts
@@ -3,6 +3,7 @@ export const runtime = 'nodejs'
 
 import { NextRequest, NextResponse } from 'next/server'
 import vision from '@google-cloud/vision'
+import fs from 'fs'
 import dayjs from 'dayjs'
 import 'dayjs/locale/ja'
 
@@ -16,8 +17,19 @@ export async function POST(req: NextRequest) {
 
     const buffer = Buffer.from(await file.arrayBuffer())
 
+    const keyPath = process.env.GCP_VISION_KEY_PATH || 'gcp-vision-key.json'
+    if (!fs.existsSync(keyPath)) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: `GCP Vision key file not found at ${keyPath}. Set GCP_VISION_KEY_PATH to override.`,
+        },
+        { status: 500 }
+      )
+    }
+
     const client = new vision.ImageAnnotatorClient({
-      keyFilename: 'gcp-vision-key.json',
+      keyFilename: keyPath,
     })
 
     const [result] = await client.textDetection({ image: { content: buffer } })


### PR DESCRIPTION
## Summary
- document how to supply Google Cloud Vision key
- load GCP key from `GCP_VISION_KEY_PATH` env in the OCR route
- return clear error when key file is missing

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b533c4c1c833291b2e1c0f26d21f3