### PR TITLE
Add user scoping to inventory pages

### DIFF
--- a/app/admin/inventory/input/page.tsx
+++ b/app/admin/inventory/input/page.tsx
@@ -40,10 +40,20 @@ export default function InventoryInputOnly() {
   }
 
   const handleAdd = async () => {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      alert('ログイン情報を取得できません')
+      return
+    }
+
     const payload = Object.fromEntries(
       Object.entries(formData).map(([k, v]) => [k, v === '' ? null : v])
     )
-    const { error } = await supabase.from('inventory').insert([payload])
+
+    const { error } = await supabase
+      .from('inventory')
+      .insert([{ ...payload, user_id: user.id }])
+
     if (error) {
       alert('保存に失敗しました')
       console.error(error)


### PR DESCRIPTION
## Summary
- include logged in user id when manually inserting inventory
- scope inventory queries to the authenticated user
- include user id for CSV imports
- restrict edit/delete actions by user id

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b533ad5c08332a60e179e4132b5bc