### PR TITLE
Implement OTP login page

### DIFF
--- a/app/setup/page.tsx
+++ b/app/setup/page.tsx
@@ -1,0 +1,10 @@
+'use client'
+
+export default function SetupPage() {
+  return (
+    <div className="p-8 text-center">
+      <h1 className="text-xl font-bold mb-4">セットアップ</h1>
+      <p>ここに初期設定を実装してください。</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- handle Supabase OTP links in `/login`
- redirect to `/setup` after successful login
- add placeholder `/setup` page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b5802c2c48332b16386c000aa0902