### PR TITLE
Implement profile setup with main warehouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 ### Authentication
 
-Use `/signup` to create an account and `/login` to access the app. After sign-up a default warehouse record is created automatically.
+Use `/signup` to create an account and `/login` to access the app. After sign-up you will be redirected to `/setup` where you can register your profile. Completing setup creates a "メイン倉庫" record automatically.

--- a/app/api/create-default-warehouse/route.ts
+++ b/app/api/create-default-warehouse/route.ts
@@ -2,13 +2,24 @@ import { NextRequest, NextResponse } from 'next/server'
 import { supabase } from '@/lib/supabase'
 
 export async function POST(req: NextRequest) {
-  const { user_id } = await req.json()
+  const { user_id, name } = await req.json()
   if (!user_id) {
     return NextResponse.json({ error: 'user_id required' }, { status: 400 })
   }
+
+  if (name) {
+    const { error: profileError } = await supabase
+      .from('profiles')
+      .upsert({ id: user_id, name })
+
+    if (profileError) {
+      return NextResponse.json({ error: profileError.message }, { status: 500 })
+    }
+  }
+
   const { error, data } = await supabase
     .from('warehouses')
-    .insert({ user_id, name: 'default' })
+    .insert({ user_id, name: 'メイン倉庫' })
     .single()
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 })

--- a/app/inventory/page.tsx
+++ b/app/inventory/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function InventoryRedirect() {
+  redirect('/admin/inventory')
+}

--- a/app/setup/page.tsx
+++ b/app/setup/page.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function SetupPage() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      if (!data.user) router.replace('/login')
+    })
+  }, [router])
+
+  const handleSetup = async () => {
+    setError(null)
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      setError('ログインが必要です')
+      return
+    }
+    if (!name.trim()) {
+      setError('名前を入力してください')
+      return
+    }
+    const res = await fetch('/api/create-default-warehouse', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user_id: user.id, name }),
+    })
+    const result = await res.json()
+    if (result.error) {
+      setError(result.error)
+      return
+    }
+    router.replace('/inventory')
+  }
+
+  return (
+    <div className="max-w-sm mx-auto mt-20 space-y-4">
+      <h1 className="text-xl font-bold text-center">初期設定</h1>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <Input
+        placeholder="お名前"
+        value={name}
+        onChange={e => setName(e.target.value)}
+      />
+      <Button className="w-full" onClick={handleSetup}>登録</Button>
+    </div>
+  )
+}

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -14,7 +14,7 @@ export default function SignupPage() {
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }) => {
-      if (data.user) router.replace('/admin/inventory')
+      if (data.user) router.replace('/inventory')
     })
   }, [router])
 
@@ -25,12 +25,7 @@ export default function SignupPage() {
       setError(error?.message || 'signup failed')
       return
     }
-    await fetch('/api/create-default-warehouse', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ user_id: data.user.id }),
-    })
-    router.replace('/admin/inventory')
+    router.replace('/setup')
   }
 
   return (


### PR DESCRIPTION
## Summary
- integrate setup API to also upsert profiles and create a メイン倉庫
- add `/setup` page to collect the user name
- redirect new users to setup from signup page
- add `/inventory` alias page
- update README about the new setup flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b58376c6c8332a3af9c7976452756