### PR TITLE
Add warehouse management pages

### DIFF
--- a/app/admin/inventory/page.tsx
+++ b/app/admin/inventory/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import Head from 'next/head'
 import { supabase } from '@/lib/supabase'
 import { Input } from '@/components/ui/input'
@@ -54,6 +55,7 @@ const columns = [
  * ------------------------------------------- */
 export default function AdminInventoryPage() {
   /* ---------- 状態 ---------- */
+  const router = useRouter()
   const [allEntries, setAllEntries]           = useState<any[]>([])
   const [entries, setEntries]                 = useState<any[]>([])
   const [editingId, setEditingId]             = useState<number | null>(null)
@@ -317,12 +319,19 @@ const exportToCSV = (row: any) => {
             className="hidden"
           />
 
-          <Button
-            onClick={() => window.open('/admin/inventory/input', '_blank')}
-            className="bg-[#191970] text-white hover:bg-[#15155d]"
-          >
-            個別登録
-          </Button>
+            <Button
+              onClick={() => window.open('/admin/inventory/input', '_blank')}
+              className="bg-[#191970] text-white hover:bg-[#15155d]"
+            >
+              個別登録
+            </Button>
+
+            <Button
+              onClick={() => router.push('/warehouses')}
+              className="bg-[#191970] text-white hover:bg-[#15155d]"
+            >
+              倉庫一覧
+            </Button>
 
           <Button
             onClick={() => setShowFilters(!showFilters)}

--- a/app/warehouses/[id]/edit/page.tsx
+++ b/app/warehouses/[id]/edit/page.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useParams } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function EditWarehousePage() {
+  const router = useRouter()
+  const params = useParams()
+  const id = params.id as string
+  const [name, setName] = useState('')
+  const [address, setAddress] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('warehouses')
+        .select('*')
+        .eq('id', id)
+        .single()
+      if (error) {
+        setError(error.message)
+      } else if (data) {
+        setName(data.name || '')
+        setAddress(data.address || '')
+      }
+      setLoading(false)
+    }
+    load()
+  }, [id])
+
+  const handleUpdate = async () => {
+    setError(null)
+    const { error } = await supabase
+      .from('warehouses')
+      .update({ name, address })
+      .eq('id', id)
+    if (error) {
+      setError(error.message)
+    } else {
+      router.push('/warehouses')
+    }
+  }
+
+  if (loading) return <div className="p-4">Loading...</div>
+
+  return (
+    <div className="max-w-sm mx-auto mt-20 space-y-4">
+      <h1 className="text-xl font-bold text-center">倉庫編集</h1>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <Input placeholder="名称" value={name} onChange={e => setName(e.target.value)} />
+      <Input placeholder="住所" value={address} onChange={e => setAddress(e.target.value)} />
+      <Button className="w-full" onClick={handleUpdate}>更新</Button>
+    </div>
+  )
+}

--- a/app/warehouses/new/page.tsx
+++ b/app/warehouses/new/page.tsx
@@ -1,0 +1,48 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+export default function NewWarehousePage() {
+  const router = useRouter()
+  const [name, setName] = useState('')
+  const [address, setAddress] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleCreate = async () => {
+    setError(null)
+    const { data } = await supabase.auth.getSession()
+    const userId = data.session?.user.id
+    if (!userId) {
+      router.replace('/login')
+      return
+    }
+    if (!name.trim()) {
+      setError('名称を入力してください')
+      return
+    }
+    const { error } = await supabase.from('warehouses').insert({
+      user_id: userId,
+      name,
+      address: address || null,
+    })
+    if (error) {
+      setError(error.message)
+    } else {
+      router.push('/warehouses')
+    }
+  }
+
+  return (
+    <div className="max-w-sm mx-auto mt-20 space-y-4">
+      <h1 className="text-xl font-bold text-center">倉庫追加</h1>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <Input placeholder="名称" value={name} onChange={e => setName(e.target.value)} />
+      <Input placeholder="住所" value={address} onChange={e => setAddress(e.target.value)} />
+      <Button className="w-full" onClick={handleCreate}>登録</Button>
+    </div>
+  )
+}

--- a/app/warehouses/page.tsx
+++ b/app/warehouses/page.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import { Button } from '@/components/ui/button'
+
+interface Warehouse {
+  id: number
+  name: string
+  address: string | null
+}
+
+export default function WarehousesPage() {
+  const router = useRouter()
+  const [warehouses, setWarehouses] = useState<(Warehouse & { count: number })[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await supabase.auth.getSession()
+      const userId = data.session?.user.id
+      if (!userId) {
+        router.replace('/login')
+        return
+      }
+      const { data: list, error } = await supabase
+        .from('warehouses')
+        .select('id, name, address')
+        .eq('user_id', userId)
+
+      if (!error && list) {
+        const withCounts = await Promise.all(
+          list.map(async (w) => {
+            const { count } = await supabase
+              .from('inventory')
+              .select('*', { count: 'exact', head: true })
+              .eq('warehouse_id', w.id)
+            return { ...w, count: count || 0 }
+          })
+        )
+        setWarehouses(withCounts)
+      }
+      setLoading(false)
+    }
+    load()
+  }, [router])
+
+  if (loading) return <div className="p-4">Loading...</div>
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-lg font-bold">倉庫一覧</h1>
+        <Link href="/warehouses/new">
+          <Button className="bg-[#191970] text-white hover:bg-[#15155d]">
+            倉庫を追加
+          </Button>
+        </Link>
+      </div>
+      <table className="w-full text-sm border">
+        <thead className="bg-gray-100">
+          <tr>
+            <th className="border px-2 py-1">名称</th>
+            <th className="border px-2 py-1">住所</th>
+            <th className="border px-2 py-1">在庫数</th>
+            <th className="border px-2 py-1"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {warehouses.map((w) => (
+            <tr key={w.id}>
+              <td className="border px-2 py-1">{w.name}</td>
+              <td className="border px-2 py-1">{w.address ?? ''}</td>
+              <td className="border px-2 py-1 text-right">{w.count}</td>
+              <td className="border px-2 py-1 text-center">
+                <Link href={`/warehouses/${w.id}/edit`}>
+                  <Button size="sm">編集</Button>
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- list warehouses filtered by user and show inventory counts
- enable creating and editing warehouses
- link to warehouse list from inventory page

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b5b9b2d6c833287cd45e311b43ec3