### PR TITLE
Add inventory listing page

### DIFF
--- a/app/inventory/page.tsx
+++ b/app/inventory/page.tsx
@@ -1,5 +1,72 @@
-import { redirect } from 'next/navigation'
+'use client'
 
-export default function InventoryRedirect() {
-  redirect('/admin/inventory')
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+import InventoryTable, { ColumnDef } from '@/components/ui/InventoryTable'
+import EditModal from '@/components/EditModal'
+
+export default function InventoryPage() {
+  const router = useRouter()
+  const [rows, setRows] = useState<any[]>([])
+  const [editing, setEditing] = useState<any | null>(null)
+
+  const fetchData = async () => {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      router.replace('/login')
+      return
+    }
+    const { data, error } = await supabase
+      .from('inventory')
+      .select('id,machine_name,type,warehouses(name),created_at,quantity')
+      .eq('user_id', user.id)
+    if (!error && data) setRows(data)
+  }
+
+  useEffect(() => { fetchData() }, [])
+
+  const handleSave = async (form: any) => {
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user || !form.id) return
+    await supabase
+      .from('inventory')
+      .update(form)
+      .eq('id', form.id)
+      .eq('user_id', user.id)
+    setEditing(null)
+    fetchData()
+  }
+
+  const columns: ColumnDef<any>[] = [
+    { key: 'machine_name', label: '台名' },
+    { key: 'type', label: '型式名' },
+    {
+      key: 'warehouses',
+      label: '倉庫名',
+      render: (row) => row.warehouses?.name || ''
+    },
+    {
+      key: 'created_at',
+      label: '登録日',
+      render: (row) => new Date(row.created_at).toLocaleDateString()
+    },
+    { key: 'quantity', label: '数量' },
+  ]
+
+  return (
+    <div className="p-4 space-y-4">
+      <InventoryTable
+        data={rows}
+        columns={columns}
+        onEdit={(row) => setEditing(row)}
+      />
+      <EditModal
+        isOpen={!!editing}
+        onClose={() => setEditing(null)}
+        onSave={handleSave}
+        data={editing || undefined}
+      />
+    </div>
+  )
 }

--- a/components/ui/InventoryTable.tsx
+++ b/components/ui/InventoryTable.tsx
@@ -1,8 +1,24 @@
 // components/InventoryTable.tsx
 import { useState, useRef, useEffect } from 'react'
 
-export default function InventoryTable({ data }: { data: any[] }) {
-  const [contextMenu, setContextMenu] = useState<{ x: number, y: number, row: any } | null>(null)
+export type ColumnDef<T> = {
+  key: string
+  label: string
+  render?: (row: T) => React.ReactNode
+}
+
+export default function InventoryTable<T>({
+  data,
+  columns,
+  onEdit,
+}: {
+  data: T[]
+  columns: ColumnDef<T>[]
+  onEdit?: (row: T) => void
+}) {
+  const [contextMenu, setContextMenu] = useState<
+    { x: number; y: number; row: T } | null
+  >(null)
   const tableRef = useRef<HTMLTableElement>(null)
 
   // 外をクリックしたらメニューを閉じる
@@ -21,24 +37,39 @@ export default function InventoryTable({ data }: { data: any[] }) {
 
   return (
     <div style={{ position: 'relative' }}>
-      <table ref={tableRef}>
+      <table ref={tableRef} className="w-full">
         <thead>
           <tr>
-            <th>機種名</th>
-            <th>型式</th>
-            <th>メーカー</th>
+            {columns.map((c) => (
+              <th key={c.key} className="px-2 py-1 text-left">
+                {c.label}
+              </th>
+            ))}
+            {onEdit && <th className="px-2 py-1" />}
           </tr>
         </thead>
         <tbody>
-          {data.map((row) => (
+          {data.map((row: T) => (
             <tr
-              key={row.id}
+              key={(row as any).id}
               onContextMenu={(e) => handleContextMenu(e, row)}
-              className="select-none"
+              className="select-none hover:bg-gray-50"
             >
-              <td>{row.machine_name}</td>
-              <td>{row.type}</td>
-              <td>{row.maker}</td>
+              {columns.map((c) => (
+                <td key={c.key} className="border px-2 py-1">
+                  {c.render ? c.render(row) : (row as any)[c.key]}
+                </td>
+              ))}
+              {onEdit && (
+                <td className="border px-2 py-1 text-center">
+                  <button
+                    onClick={() => onEdit(row)}
+                    className="text-blue-600 hover:underline"
+                  >
+                    編集
+                  </button>
+                </td>
+              )}
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## Summary
- extend `InventoryTable` component to accept column definition and edit handler
- implement `/inventory` page that loads inventory data for the current user
- open `EditModal` for editing rows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b5b8f07148332b7a4523e7504778c