### PR TITLE
Add custom 500 error page

### DIFF
--- a/app/500.tsx
+++ b/app/500.tsx
@@ -1,0 +1,3 @@
+export default function Custom500() {
+  return <h1>500 - サーバーエラーが発生しました</h1>;
+}


### PR DESCRIPTION
## Summary
- add a 500 error page in the `app/` directory so static export creates `500.html`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b63ff5a908332ad76cd9a787ea2c8