### PR TITLE
Insert use client directive

### DIFF
--- a/components/ColumnPresetModal.tsx
+++ b/components/ColumnPresetModal.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Dialog } from '@headlessui/react'
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase'


### PR DESCRIPTION
## Summary
- mark `ColumnPresetModal` as a client component

## Testing
- `npm test --silent`
- `CI=true npm run lint --silent` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_685b65c328608332aee6ca0033d6da60