### PR TITLE
Add CSV/date utilities and tests

### DIFF
--- a/lib/__tests__/inventory-utils.test.ts
+++ b/lib/__tests__/inventory-utils.test.ts
@@ -1,0 +1,26 @@
+import { rowsToCsv, formatDateJP } from '../utils'
+
+describe('rowsToCsv', () => {
+  it('converts rows to CSV string', () => {
+    const rows = [
+      { a: 1, b: 2 },
+      { a: 3, b: 4 },
+    ]
+    const csv = rowsToCsv(rows)
+    expect(csv).toBe('a,b\r\n1,2\r\n3,4')
+  })
+})
+
+describe('formatDateJP', () => {
+  it('formats valid date strings', () => {
+    expect(formatDateJP('2025-06-25')).toBe('2025/6/25')
+  })
+
+  it('returns hyphen for undefined dates', () => {
+    expect(formatDateJP()).toBe('-')
+  })
+
+  it('returns original value for invalid dates', () => {
+    expect(formatDateJP('not-a-date')).toBe('not-a-date')
+  })
+})

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,18 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import Papa from 'papaparse'
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function rowsToCsv(rows: Record<string, any>[]): string {
+  return Papa.unparse(rows)
+}
+
+export function formatDateJP(date?: string | Date): string {
+  if (!date) return '-'
+  const dt = typeof date === 'string' ? new Date(date) : date
+  if (isNaN(dt.getTime())) return String(date)
+  return dt.toLocaleDateString('ja-JP')
 }


### PR DESCRIPTION
## Summary
- add `rowsToCsv` and `formatDateJP` helpers in `lib/utils.ts`
- cover these utilities with Jest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b67772b9083329888c62d77bf1fca