### PR TITLE
Add 404/500 error pages

### DIFF
--- a/app/404/page.tsx
+++ b/app/404/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '../not-found'

--- a/app/500/page.tsx
+++ b/app/500/page.tsx
@@ -1,0 +1,5 @@
+import ErrorPage from '@/components/ErrorPage'
+
+export default function Page() {
+  return <ErrorPage title="サーバーエラーが発生しました" />
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import ErrorPage from '@/components/ErrorPage'
+
+export default function GlobalError() {
+  return <ErrorPage title="サーバーエラーが発生しました" />
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,5 @@
+import ErrorPage from '@/components/ErrorPage'
+
+export default function NotFound() {
+  return <ErrorPage title="ページが見つかりません" />
+}

--- a/components/ErrorPage.tsx
+++ b/components/ErrorPage.tsx
@@ -1,0 +1,13 @@
+import Link from 'next/link'
+
+export default function ErrorPage({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="mt-20 text-center space-y-4">
+      <h1 className="text-4xl font-bold">{title}</h1>
+      {description && <p>{description}</p>}
+      <Link href="/" className="text-blue-600 underline">
+        ホームに戻る
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add reusable ErrorPage component
- implement 404 and server error pages
- expose /404 and /500 routes
- handle global errors with custom page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b5eaae1688332a52346bdb4b909a1