### PR TITLE
Add CSV download helper and tests

### DIFF
--- a/app/admin/inventory/page.tsx
+++ b/app/admin/inventory/page.tsx
@@ -6,7 +6,7 @@ import Head from 'next/head'
 import { supabase } from '@/lib/supabase'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
-import Papa from 'papaparse'
+import { downloadCsv } from '@/lib/utils'
 import EditModal from '@/components/EditModal'
 import ColumnPresetModal from '@/components/ColumnPresetModal'
 import { fetchLatestPreset, listPresets, deletePreset } from '@/lib/presets'
@@ -297,12 +297,7 @@ export default function AdminInventoryPage() {
 
   // ダウンロード機能
 const exportToCSV = (row: any) => {
-  const csv = `${Object.keys(row).join(',')}\n${Object.values(row).join(',')}`;
-  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
-  const link = document.createElement('a');
-  link.href = URL.createObjectURL(blob);
-  link.download = 'pachimart_row.csv';
-  link.click();
+  downloadCsv([row], 'pachimart_row.csv');
 };
 
   const handleExportCsv = () => {
@@ -314,14 +309,7 @@ const exportToCSV = (row: any) => {
       })
       return obj
     })
-    const csv = Papa.unparse(rows)
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement('a')
-    link.href = url
-    link.download = 'inventory.csv'
-    link.click()
-    URL.revokeObjectURL(url)
+    downloadCsv(rows, 'inventory.csv')
   }
 
   /* ---------- UI ---------- */

--- a/lib/__tests__/downloadCsv.test.ts
+++ b/lib/__tests__/downloadCsv.test.ts
@@ -1,0 +1,23 @@
+import { downloadCsv } from '../utils'
+
+describe('downloadCsv', () => {
+  it('generates quoted CSV and triggers download', async () => {
+    const rows = [{ a: '1,2', b: '3"4' }]
+    const link: any = { click: jest.fn(), set download(v) { this._download = v }, get download() { return this._download } }
+    ;(global as any).document = { createElement: jest.fn(() => link) }
+    const createSpy = jest.spyOn(URL, 'createObjectURL').mockReturnValue('blob:')
+    const revokeSpy = jest.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+
+    downloadCsv(rows, 'rows.csv')
+
+    expect(link.download).toBe('rows.csv')
+    const blob = createSpy.mock.calls[0][0] as Blob
+    const text = await blob.text()
+    expect(text).toBe('a,b\r\n"1,2","3""4"')
+
+    expect(link.click).toHaveBeenCalled()
+
+    createSpy.mockRestore()
+    revokeSpy.mockRestore()
+  })
+})

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,6 +10,18 @@ export function rowsToCsv(rows: Record<string, any>[]): string {
   return Papa.unparse(rows)
 }
 
+export function downloadCsv(rows: Record<string, any>[], filename: string): void {
+  const csv = rowsToCsv(rows)
+  if (typeof document === 'undefined') return
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = filename
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
 export function formatDateJP(date?: string | Date): string {
   if (!date) return '-'
   const dt = typeof date === 'string' ? new Date(date) : date


### PR DESCRIPTION
## Summary
- extract downloadCsv helper in `lib/utils`
- use the helper in admin inventory page
- test downloadCsv generation and quoting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b6ba25d688332a5f594933334c1f7