### PR TITLE
Use shared date format helper

### DIFF
--- a/app/admin/inventory/page.tsx
+++ b/app/admin/inventory/page.tsx
@@ -14,6 +14,7 @@ import { Download,  Pencil, Trash2 } from 'lucide-react'
 import { Package } from 'lucide-react'
 import { MoreVertical } from 'lucide-react';
 import { Upload, FileText } from 'lucide-react'
+import { formatDateJP } from '@/lib/utils'
 
 
 
@@ -255,15 +256,6 @@ export default function AdminInventoryPage() {
     setSelectedColumns(p =>
       p.includes(k) ? p.filter(x => x !== k) : [...p, k],
     )
-  }
-
-  /* ---------- 日付表示 ---------- */
-  const dateFmt = (d?: string) => {
-    if (!d) return '-'
-    const dt = new Date(d)
-    return isNaN(dt.getTime())
-      ? d
-      : `${dt.getFullYear().toString().slice(-2)}/${dt.getMonth() + 1}/${dt.getDate()}`
   }
 
   /* ---------- 外クリックでメニュー全部閉じる ---------- */
@@ -514,7 +506,7 @@ const exportToCSV = (row: any) => {
       ) : c.key === 'warehouse_id'
         ? row.warehouses?.name ?? '-'
         : c.key.includes('date') || c.key.includes('expiry')
-        ? dateFmt(row[c.key])
+        ? formatDateJP(row[c.key])
         : String(row[c.key] ?? '-')}
     </td>
   ))}


### PR DESCRIPTION
## Summary
- remove local date formatter in inventory admin page
- reuse `formatDateJP` helper so dates all use four-digit year format

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b6ba2c64c8332b03a4c239b5f9c53