### PR TITLE
Add GCP vision key env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 # Example environment variables required to run the application
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+# Path to the Google Cloud Vision key used for OCR (default gcp-vision-key.json)
+GCP_VISION_KEY_PATH=gcp-vision-key.json

--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ This project uses [`next/font`](https://nextjs.org/docs/app/building-your-applic
 ### Google Cloud Vision
 
 OCR features require a Google Cloud Vision service account key. Place the JSON
-key at `gcp-vision-key.json` in the project root or specify a custom path using
-the `GCP_VISION_KEY_PATH` environment variable when running the server.
+key at `gcp-vision-key.json` in the project root or specify a custom path by
+setting `GCP_VISION_KEY_PATH` in your environment (see `.env.example`) when
+running the server.
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
- document `GCP_VISION_KEY_PATH` in `.env.example`
- mention the environment variable in the Google Cloud Vision section of the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b7004c08483328f529b4ebaff08aa