### PR TITLE
Add Node engines info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
+This project requires **Node.js version 18 or higher**.
+
 First, run the development server:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "inventory-demo",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",


### PR DESCRIPTION
## Summary
- specify Node >=18 in `package.json`
- document the Node version requirement in the README

## Testing
- `npm install`
- `npm test` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_e_685b756192f4833293e5162b029b2804