### PR TITLE
Update README with OTP login info

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 Use `/signup` to create an account and `/login` to access the app. After sign-up you will be redirected to `/setup` where you can register your profile. Completing setup creates a "メイン倉庫" record automatically.
 
+### OTP Login
+
+Visit `/signup` and enter your email address to receive a one-time login link. The app
+uses Supabase `signInWithOtp` under the hood, so make sure the following
+environment variables are configured (see `.env.example`):
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+
+After clicking the link in the email, the session is authenticated and you will be
+redirected to `/setup` to complete your profile.
+
 ### FAQ
 
 Basic usage tips and troubleshooting steps are available at `/faq`.


### PR DESCRIPTION
## Summary
- add instructions for OTP login flow in the README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b7903ede88332beaefb543727d807