### PR TITLE
Add metadata to 404 and 500 pages

### DIFF
--- a/app/404/page.tsx
+++ b/app/404/page.tsx
@@ -1,0 +1,11 @@
+import ErrorPage from '@/components/ErrorPage'
+
+export const metadata = {
+  title: 'ページが見つかりません',
+}
+
+export default function NotFoundPage() {
+  return (
+    <ErrorPage title="ページが見つかりません" description="お探しのページは存在しません。" />
+  )
+}

--- a/app/500/page.tsx
+++ b/app/500/page.tsx
@@ -1,0 +1,9 @@
+import ErrorPage from '@/components/ErrorPage'
+
+export const metadata = {
+  title: 'サーバーエラー',
+}
+
+export default function Custom500Page() {
+  return <ErrorPage title="サーバーエラー" description="サーバーエラーが発生しました" />
+}


### PR DESCRIPTION
## Summary
- add custom error pages under `app/404` and `app/500`
- export `metadata` with Japanese titles for each page

## Testing
- `npm test` *(fails: Property `createObjectURL` does not exist in the provided object)*

------
https://chatgpt.com/codex/tasks/task_e_685b78f603488332b1dfec9107ad104a