### PR TITLE
Add global error page with retry option

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import ErrorPage from '@/components/ErrorPage'
+import { Button } from '@/components/ui/button'
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <div className="py-8 text-center space-y-4">
+      <ErrorPage title="エラーが発生しました" description={error.message} />
+      <Button onClick={reset}>再試行</Button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- show a global error screen
- pass error message to `ErrorPage`
- add a retry button

## Testing
- `npm test` *(fails: downloadCsv.test.ts issue)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing jest globals)*

------
https://chatgpt.com/codex/tasks/task_e_685b78f5856483329b10b5c6b06b0a05