### PR TITLE
Add password signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,17 +48,16 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 
 Use `/signup` to create an account and `/login` to access the app. After sign-up you will be redirected to `/setup` where you can register your profile. Completing setup creates a "メイン倉庫" record automatically.
 
-### OTP Login
+### Email & Password Signup
 
-Visit `/signup` and enter your email address to receive a one-time login link. The app
-uses Supabase `signInWithOtp` under the hood, so make sure the following
+Visit `/signup` to create an account using your email address and a password.
+Supabase's `signUp` method handles account creation, so ensure the following
 environment variables are configured (see `.env.example`):
 
 - `NEXT_PUBLIC_SUPABASE_URL`
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 
-After clicking the link in the email, the session is authenticated and you will be
-redirected to `/setup` to complete your profile.
+After sign-up you will be redirected to `/setup` to complete your profile.
 
 ### FAQ
 

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button'
 export default function SignupPage() {
   const router = useRouter()
   const [email, setEmail] = useState('')
-  const [message, setMessage] = useState<string | null>(null)
+  const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -20,13 +20,11 @@ export default function SignupPage() {
 
   const handleSignup = async () => {
     setError(null)
-    setMessage(null)
-    const { error } = await supabase.auth.signInWithOtp({ email })
+    const { error } = await supabase.auth.signUp({ email, password })
     if (error) {
       setError(error.message)
     } else {
-      setMessage('メールを確認してください')
-      router.replace('/admin/inventory')
+      router.replace('/setup')
     }
   }
 
@@ -34,15 +32,20 @@ export default function SignupPage() {
     <div className="max-w-sm mx-auto mt-20 space-y-4">
       <h1 className="text-xl font-bold text-center">サインアップ</h1>
       {error && <p className="text-red-500 text-sm">{error}</p>}
-      {message && <p className="text-green-500 text-sm">{message}</p>}
       <Input
         type="email"
         placeholder="Email"
         value={email}
         onChange={e => setEmail(e.target.value)}
       />
+      <Input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
       <Button className="w-full" onClick={handleSignup}>
-        登録用リンクを送信
+        アカウント作成
       </Button>
     </div>
   )


### PR DESCRIPTION
## Summary
- enable email/password signup
- document signup workflow in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b85ab830c83328be95db4deb7dc56