### PR TITLE
Add signup and login buttons on landing page

### DIFF
--- a/components/lp/Hero.tsx
+++ b/components/lp/Hero.tsx
@@ -9,9 +9,14 @@ export default function Hero() {
       <div className="max-w-3xl mx-auto">
         <h1 className="text-4xl font-bold mb-4">パチ番頭</h1>
         <p className="text-lg mb-8">パチンコホール向け在庫管理をもっとスマートに、もっと正確に。</p>
-        <Button asChild>
-          <Link href="/signup">無料で始める</Link>
-        </Button>
+        <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+          <Button asChild>
+            <Link href="/signup">新規登録</Link>
+          </Button>
+          <Button variant="outline" asChild>
+            <Link href="/login">ログイン</Link>
+          </Button>
+        </div>
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary
- add dedicated signup and login buttons in the landing hero

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b8fdfcba0833288cadf8c4a793746