### PR TITLE
Add auth error translations and tests

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
+import { translateAuthError } from '@/lib/authErrors'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 
@@ -22,7 +23,7 @@ export default function LoginPage() {
     setError(null)
     const { error } = await supabase.auth.signInWithPassword({ email, password })
     if (error) {
-      setError(error.message)
+      setError(translateAuthError(error.message))
     } else {
       router.replace('/admin/inventory')
     }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
+import { translateAuthError } from '@/lib/authErrors'
 import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 
@@ -22,7 +23,7 @@ export default function SignupPage() {
     setError(null)
     const { error } = await supabase.auth.signUp({ email, password })
     if (error) {
-      setError(error.message)
+      setError(translateAuthError(error.message))
     } else {
       router.replace('/setup')
     }

--- a/lib/__tests__/authErrors.test.ts
+++ b/lib/__tests__/authErrors.test.ts
@@ -1,0 +1,13 @@
+import { translateAuthError } from '../authErrors'
+
+describe('translateAuthError', () => {
+  it('translates known messages', () => {
+    expect(translateAuthError('Invalid login credentials')).toBe('メールアドレスまたはパスワードが間違っています')
+    expect(translateAuthError('Email not confirmed')).toBe('メールアドレスが確認されていません')
+    expect(translateAuthError('User already registered')).toBe('すでに登録済みのメールアドレスです')
+  })
+
+  it('returns original message for unknown errors', () => {
+    expect(translateAuthError('Something else')).toBe('Something else')
+  })
+})

--- a/lib/authErrors.ts
+++ b/lib/authErrors.ts
@@ -1,0 +1,12 @@
+export function translateAuthError(msg: string): string {
+  switch (msg) {
+    case 'Invalid login credentials':
+      return 'メールアドレスまたはパスワードが間違っています';
+    case 'Email not confirmed':
+      return 'メールアドレスが確認されていません';
+    case 'User already registered':
+      return 'すでに登録済みのメールアドレスです';
+    default:
+      return msg;
+  }
+}


### PR DESCRIPTION
## Summary
- add `translateAuthError` helper
- use the helper on login and signup pages
- test auth error translations

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685b938c7bfc83329ad7490ddf071fd5