### PR TITLE
Add custom admin inventory layout

### DIFF
--- a/app/(dashboard)/admin/inventory/layout.tsx
+++ b/app/(dashboard)/admin/inventory/layout.tsx
@@ -1,0 +1,18 @@
+'use client'
+
+import DashboardNav from '@/components/DashboardNav'
+
+export default function AdminInventoryLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <DashboardNav />
+      <div className="p-4 flex-1">
+        {children}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `layout.tsx` for the admin inventory pages without the BackButton

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685bacb5680c83328144472d50274a9b