### PR TITLE
Add warehouses option to settings menu

### DIFF
--- a/components/ui/SettingsMenu.tsx
+++ b/components/ui/SettingsMenu.tsx
@@ -23,7 +23,18 @@ export default function SettingsMenu() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent className="bg-white rounded shadow p-2 mt-2">
-        <DropdownMenuItem className="hover:bg-gray-100 p-2 rounded">アカウント設定</DropdownMenuItem>
+        <DropdownMenuItem
+          className="hover:bg-gray-100 p-2 rounded"
+          onClick={() => router.push('/warehouses')}
+        >
+          倉庫設定
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          className="hover:bg-gray-100 p-2 rounded"
+          onClick={() => router.push('/settings/account')}
+        >
+          アカウント設定
+        </DropdownMenuItem>
         <DropdownMenuItem className="hover:bg-gray-100 p-2 rounded" onClick={handleLogout}>
           ログアウト
         </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- add a link to warehouse settings in `SettingsMenu`
- make account settings item navigate to the account page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685bacacd3288332aa3f035da24d36ae