### PR TITLE
Remove header links from dashboard nav

### DIFF
--- a/components/DashboardNav.tsx
+++ b/components/DashboardNav.tsx
@@ -15,15 +15,7 @@ export default function DashboardNav() {
 
   return (
     <nav className="flex items-center gap-4 p-4 border-b bg-gray-50">
-      <Link href="/admin/inventory" className="font-semibold">
-        在庫
-      </Link>
-      <Link href="/warehouses" className="font-semibold">
-        倉庫
-      </Link>
-      <Link href="/settings/account" className="font-semibold">
-        アカウント設定
-      </Link>
+
       <div className="flex-1" />
     
     </nav>


### PR DESCRIPTION
## Summary
- remove "在庫", "倉庫", and "アカウント設定" from the dashboard navigation

## Testing
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_685bb0c782e48332ac89a37ed2aef3c3