### PR TITLE
Add warehouse context

### DIFF
--- a/app/(dashboard)/admin/inventory/page.tsx
+++ b/app/(dashboard)/admin/inventory/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useContext } from 'react'
 import { useRouter } from 'next/navigation'
 import Head from 'next/head'
 import { supabase } from '@/lib/supabase'
@@ -15,6 +15,7 @@ import { Download, Pencil, Trash2 } from 'lucide-react'
 import { Package } from 'lucide-react'
 import { Upload, FileText } from 'lucide-react'
 import { formatDateJP } from '@/lib/utils'
+import { WarehouseContext } from '@/components/WarehouseContext'
 
 
 
@@ -109,6 +110,8 @@ export default function AdminInventoryPage() {
     [...new Set(allEntries.map(e => e.maker).filter(Boolean))].sort()
   const [tableSearch, setTableSearch] = useState('')
 
+  const { selectedWarehouseId } = useContext(WarehouseContext)
+
   /* ---------- プリセット読み込み ---------- */
   useEffect(() => {
     const load = async () => {
@@ -138,11 +141,14 @@ export default function AdminInventoryPage() {
       .from('inventory')
       .select('*, warehouses(name)')
       .eq('user_id', user.id)
+    if (selectedWarehouseId) {
+      query = query.eq('warehouse_id', selectedWarehouseId)
+    }
     if (sortColumn) query = query.order(sortColumn, { ascending: sortAsc })
     const { data, error } = await query
     if (!error && data) setAllEntries(data)
   }
-  useEffect(() => { fetchData() }, [sortColumn, sortAsc])
+  useEffect(() => { fetchData() }, [sortColumn, sortAsc, selectedWarehouseId])
 
   const saveRow = async (data: any) => {
     const { data: { user } } = await supabase.auth.getUser()

--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import DashboardHeader from '@/components/DashboardHeader'
+import { WarehouseProvider } from '@/components/WarehouseContext'
 
 export default function DashboardLayout({
   children,
@@ -8,11 +9,13 @@ export default function DashboardLayout({
   children: React.ReactNode
 }) {
   return (
-    <div className="min-h-screen flex flex-col">
-      <DashboardHeader />
-      <div className="p-4 flex-1">
-        {children}
+    <WarehouseProvider>
+      <div className="min-h-screen flex flex-col">
+        <DashboardHeader />
+        <div className="p-4 flex-1">
+          {children}
+        </div>
       </div>
-    </div>
+    </WarehouseProvider>
   )
 }

--- a/components/WarehouseContext.tsx
+++ b/components/WarehouseContext.tsx
@@ -1,0 +1,21 @@
+"use client"
+import { createContext, useState } from 'react'
+
+export interface WarehouseContextValue {
+  selectedWarehouseId: string | null
+  setSelectedWarehouseId: (id: string | null) => void
+}
+
+export const WarehouseContext = createContext<WarehouseContextValue>({
+  selectedWarehouseId: null,
+  setSelectedWarehouseId: () => {},
+})
+
+export function WarehouseProvider({ children }: { children: React.ReactNode }) {
+  const [selectedWarehouseId, setSelectedWarehouseId] = useState<string | null>(null)
+  return (
+    <WarehouseContext.Provider value={{ selectedWarehouseId, setSelectedWarehouseId }}>
+      {children}
+    </WarehouseContext.Provider>
+  )
+}

--- a/components/WarehouseSelect.tsx
+++ b/components/WarehouseSelect.tsx
@@ -1,8 +1,12 @@
 "use client";
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useContext } from 'react'
 import { supabase } from '@/lib/supabase'
+import { WarehouseContext } from './WarehouseContext'
+
 export default function WarehouseSelect() {
+  const { selectedWarehouseId, setSelectedWarehouseId } = useContext(WarehouseContext)
   const [warehouses, setWarehouses] = useState<any[]>([])
+
   useEffect(() => {
     supabase.auth.getSession().then(async ({ data }) => {
       const userId = data.session?.user.id
@@ -14,8 +18,13 @@ export default function WarehouseSelect() {
       setWarehouses(ws || [])
     })
   }, [])
+
   return (
-    <select className="border px-3 py-[6px] h-[38px] rounded">
+    <select
+      className="border px-3 py-[6px] h-[38px] rounded"
+      value={selectedWarehouseId ?? ''}
+      onChange={e => setSelectedWarehouseId(e.target.value || null)}
+    >
       <option value="">全倉庫</option>
       {warehouses.map(w => (
         <option key={w.id} value={w.id}>{w.name}</option>


### PR DESCRIPTION
## Summary
- add a WarehouseContext and provider to track the selected warehouse
- update `WarehouseSelect` to read/write the selected warehouse from context
- wrap dashboard pages with the provider so any page can read the warehouse ID
- filter inventory by selected warehouse and refresh when it changes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e1e8e79b48332973832288e24a186